### PR TITLE
fix(google_chat_callbacks): ensure webhook URL starts with 'https'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Create a Google Chat Space and Webhook
 - Access the Airflow Web UI.
 - Navigate to the Connections Page.
 - Add a New Connection.
-- In the host section, paste the webhook URL (excluding the key), and add the key to the password box.
+- In the host section, paste the webhook URL.
 
 `For the purpose of this tutorial, a connection named 'gchat_webhook' has already been added.`
 

--- a/google_chat_callbacks.py
+++ b/google_chat_callbacks.py
@@ -162,6 +162,9 @@ def task_success_alert(context):
         }]
     }
     full_url = _get_webhook_url(GCHAT_CONNECTION)
+    if not full_url.startswith('http'):
+        full_url = f"https://{full_url}"
+        
     print("sending alert card")
     _make_http_request(body, full_url)
 


### PR DESCRIPTION
Hello @kashif-se thanks you for creating and sharing this useful integration! 🙏.

I want to make few changements about this repo

1. Documentation Update:
   - Modified the webhook configuration instructions to specify that the complete webhook URL (including both the key and token) should be pasted into the host field of the Airflow connection.
   - This simplifies the setup process by removing the need to split the URL between host and password fields.

2. Code Enhancement:
   - Added URL validation to ensure proper formatting
   - Added a safety check to automatically prepend 'https://' if the protocol is missing from the webhook URL
   - This change makes the integration more robust by handling cases where the URL might not include the protocol
   
   
   Thanks, you